### PR TITLE
Align year selector to use zero indexed months

### DIFF
--- a/src/zebra_datepicker.src.js
+++ b/src/zebra_datepicker.src.js
@@ -1551,7 +1551,7 @@
                     if ($.inArray('months', views) === -1)
 
                         // put selected date in the element the plugin is attached to, and hide the date picker
-                        select_date(selected_year, 1, 1, 'years', $(this));
+                        select_date(selected_year, 0, 1, 'years', $(this));
 
                     else {
 


### PR DESCRIPTION
When using a year selector, the datepicker will return _February_ of the selected year due to the fact that the JavaScript Date object's `month` value is zero index based. Updating the value passed here will direct the `select_date` function to pass the correct `month` value to the Date object.

```
**Example**
Selected year: 2018
Expected Date obj value: Mon Jan 01 2018 12:00:00 GMT+0000
Actual Date obj value: Thu Feb 01 2018 12:00:00 GMT+0000
```

See [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date](url)